### PR TITLE
Edge and Node Drawing Options

### DIFF
--- a/lib/drawGraph.js
+++ b/lib/drawGraph.js
@@ -82,12 +82,12 @@ function curvedPath(Ax, Ay, Bx, By, M) {
   return [Ax, Ay, Kx, Ky, Bx, By];
 }
 
-function drawNodes(canvas, graph, xScale, yScale) {
+function drawNodes(canvas, graph, xScale, yScale, options) {
   const { nodes } = graph;
+  const { nodeAlpha } = options;
 
   const context = canvas.getContext('2d');
   context.save();
-  const nodeAlpha = 0.8;
   context.globalAlpha = nodeAlpha;
 
   // draw in the nodes
@@ -109,12 +109,14 @@ function drawNodes(canvas, graph, xScale, yScale) {
   context.restore();
 }
 
-function drawLinks(canvas, graph, xScale, yScale) {
+function drawLinks(canvas, graph, xScale, yScale, options) {
   const { links } = graph;
-  const curvedLinks = true;
-  const linkAlpha = 0.2;
-  const linkStrokeWidth = 1;
-  const gradientLinks = true;
+  const {
+    curvedLinks,
+    gradientLinks,
+    linkAlpha,
+    linkStrokeWidth
+  } = options;
 
   const context = canvas.getContext('2d');
   context.save();
@@ -173,12 +175,17 @@ function drawLinks(canvas, graph, xScale, yScale) {
   context.restore();
 }
 
-function drawGraph(graph, options) {
+function drawGraph(graph, options = {}) {
   const {
     width = 800,
     height = 800,
     backgroundColor = '#ffffff',
     outputPath,
+    curvedLinks = true,
+    linkAlpha = 0.2,
+    linkStrokeWidth = 1,
+    gradientLinks = true,
+    nodeAlpha = 0.8
   } = options;
 
   const padding = { top: 20, right: 20, bottom: 20, left: 20 };
@@ -212,8 +219,8 @@ function drawGraph(graph, options) {
     .domain(yExtent)
     .range([0, plotAreaHeight]);
 
-  drawLinks(canvas, graph, xScale, yScale);
-  drawNodes(canvas, graph, xScale, yScale);
+  drawLinks(canvas, graph, xScale, yScale, options);
+  drawNodes(canvas, graph, xScale, yScale, options);
 
   // if an output path is provided, save it
   if (outputPath) {

--- a/lib/drawGraph.js
+++ b/lib/drawGraph.js
@@ -111,12 +111,7 @@ function drawNodes(canvas, graph, xScale, yScale, options) {
 
 function drawLinks(canvas, graph, xScale, yScale, options) {
   const { links } = graph;
-  const {
-    curvedLinks,
-    gradientLinks,
-    linkAlpha,
-    linkStrokeWidth
-  } = options;
+  const { curvedLinks, gradientLinks, linkAlpha, linkStrokeWidth } = options;
 
   const context = canvas.getContext('2d');
   context.save();
@@ -185,7 +180,7 @@ function drawGraph(graph, options = {}) {
     linkAlpha = 0.2,
     linkStrokeWidth = 1,
     gradientLinks = true,
-    nodeAlpha = 0.8
+    nodeAlpha = 0.8,
   } = options;
 
   const padding = { top: 20, right: 20, bottom: 20, left: 20 };


### PR DESCRIPTION
This PR allows users to pass in various options to the `drawNodes` and `drawEdges` functions of the `drawGraph` part of `graph-wrangle`, which means, basically, that you can control the following attributes from configuration (though reasonable defaults are present):
- `nodeAlpha`, which controls the opacity of nodes, and which defaults `0.8`.
- `curvedLinks`, which controls if the edges in the graph are curved or not, and which defaults to `true`.
- `gradientLinks`, which controls if the edges in the graph are colored by gradient, and which defaults to `true`.
- `linkAlpha`, which controls the opacity of the edges, and which defaults to `0.2`.
- `linkStrokeWidth`, which controls the stroke width of the edges, and which defaults to `1`.